### PR TITLE
Expose storage helpers and fix modal issues

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -28,6 +28,7 @@
             min-height: 100vh;
             position: relative;
             overflow-x: hidden;
+            touch-action: pan-y;
         }
 
         /* PWAインストールプロンプト */

--- a/index.html
+++ b/index.html
@@ -492,19 +492,27 @@ if ('serviceWorker' in navigator) {
             filterPhase: 'all'
         };
 
+        function saveData() {
+            DataManager.saveData(app);
+        }
+
+        function loadData() {
+            const loadedData = DataManager.loadData();
+            if (loadedData) {
+                app.ideas = loadedData.ideas;
+                app.projects = loadedData.projects;
+                app.logs = loadedData.logs;
+                app.improvements = loadedData.improvements;
+                app.apiKey = loadedData.apiKey;
+            }
+        }
+
         
 
         // 初期化
       document.addEventListener('DOMContentLoaded', function() {
     // データを読み込む
-    const loadedData = DataManager.loadData();
-    if (loadedData) {
-        app.ideas = loadedData.ideas;
-        app.projects = loadedData.projects;
-        app.logs = loadedData.logs;
-        app.improvements = loadedData.improvements;
-        app.apiKey = loadedData.apiKey;
-    }
+    loadData();
     
     renderDashboard();
     setupEventListeners();
@@ -543,17 +551,17 @@ if ('serviceWorker' in navigator) {
             let touchEndX = 0;
             let touchStartY = 0;
             let touchEndY = 0;
-            const mainContent = document.querySelector('.main-content');
+            const swipeTarget = document.body;
             const sections = ['dashboard', 'play', 'calendar', 'daily', 'weekly', 'monthly', 'quarterly', 'completed', 'trash'];
             
             // タッチ開始
-            mainContent.addEventListener('touchstart', function(e) {
+            swipeTarget.addEventListener('touchstart', function(e) {
                 touchStartX = e.changedTouches[0].screenX;
                 touchStartY = e.changedTouches[0].screenY;
             }, { passive: true });
-            
+
             // タッチ終了
-            mainContent.addEventListener('touchend', function(e) {
+            swipeTarget.addEventListener('touchend', function(e) {
                 touchEndX = e.changedTouches[0].screenX;
                 touchEndY = e.changedTouches[0].screenY;
                 handleSwipe();
@@ -636,7 +644,14 @@ if ('serviceWorker' in navigator) {
         // 複数タブ同期処理
         function handleStorageChange(e) {
             if (e.key && e.key.startsWith('pdca_')) {
-                loadData();
+                const loadedData = DataManager.loadData();
+                if (loadedData) {
+                    app.ideas = loadedData.ideas;
+                    app.projects = loadedData.projects;
+                    app.logs = loadedData.logs;
+                    app.improvements = loadedData.improvements;
+                    app.apiKey = loadedData.apiKey;
+                }
                 renderCurrentSection();
                 UI.showToast('データが更新されました', 'success');
             }
@@ -1876,7 +1891,7 @@ if ('serviceWorker' in navigator) {
             });
             
             // 最終チェック日を更新
-            localStorage.setItem(SDataManager.STORAGE_KEYS.LAST_CHECK_DATE, today.toDateString());
+            localStorage.setItem(DataManager.STORAGE_KEYS.LAST_CHECK_DATE, today.toDateString());
             
             saveData();
             closeModal('logModal');
@@ -2710,7 +2725,7 @@ ${quarterlyImprovements.slice(-10).map(imp => {
         // 毎日のリマインダーチェック
         function checkDailyReminder() {
             const today = new Date().toDateString();
-            const lastCheckDate = localStorage.getItem(STORAGE_KEYS.LAST_CHECK_DATE);
+            const lastCheckDate = localStorage.getItem(DataManager.STORAGE_KEYS.LAST_CHECK_DATE);
             
             // 今日まだチェックしていない場合
             if (lastCheckDate !== today) {
@@ -2735,7 +2750,7 @@ ${quarterlyImprovements.slice(-10).map(imp => {
                         document.getElementById('reminderBanner').classList.add('show');
                         
                         // ブラウザ通知を送信
-                        if (localStorage.getItem(STORAGE_KEYS.NOTIFICATION_SETTINGS) === 'enabled') {
+                        if (localStorage.getItem(DataManager.STORAGE_KEYS.NOTIFICATION_SETTINGS) === 'enabled') {
                             sendNotification();
                         }
                     }
@@ -2770,32 +2785,32 @@ ${quarterlyImprovements.slice(-10).map(imp => {
 
         // 通知設定の切り替え
         function toggleNotifications() {
-            const currentStatus = localStorage.getItem(STORAGE_KEYS.NOTIFICATION_SETTINGS);
+            const currentStatus = localStorage.getItem(DataManager.STORAGE_KEYS.NOTIFICATION_SETTINGS);
             const newStatus = currentStatus === 'enabled' ? 'disabled' : 'enabled';
             
             if (newStatus === 'enabled' && 'Notification' in window) {
                 if (Notification.permission === 'default') {
                     Notification.requestPermission().then(permission => {
                         if (permission === 'granted') {
-                            localStorage.setItem(STORAGE_KEYS.NOTIFICATION_SETTINGS, 'enabled');
+                            localStorage.setItem(DataManager.STORAGE_KEYS.NOTIFICATION_SETTINGS, 'enabled');
                             updateNotificationStatus();
                         }
                     });
                 } else if (Notification.permission === 'granted') {
-                    localStorage.setItem(STORAGE_KEYS.NOTIFICATION_SETTINGS, 'enabled');
+                    localStorage.setItem(DataManager.STORAGE_KEYS.NOTIFICATION_SETTINGS, 'enabled');
                     updateNotificationStatus();
                 } else {
                     alert('ブラウザの設定で通知を許可してください');
                 }
             } else {
-                localStorage.setItem(STORAGE_KEYS.NOTIFICATION_SETTINGS, 'disabled');
+                localStorage.setItem(DataManager.STORAGE_KEYS.NOTIFICATION_SETTINGS, 'disabled');
                 updateNotificationStatus();
             }
         }
 
         // 通知ステータスの表示更新
         function updateNotificationStatus() {
-            const status = localStorage.getItem(STORAGE_KEYS.NOTIFICATION_SETTINGS);
+            const status = localStorage.getItem(DataManager.STORAGE_KEYS.NOTIFICATION_SETTINGS);
             const statusElement = document.getElementById('notificationStatus');
             if (statusElement) {
                 statusElement.textContent = status === 'enabled' ? '通知がオンです' : '通知をオンにする';
@@ -2812,7 +2827,7 @@ ${quarterlyImprovements.slice(-10).map(imp => {
             }
             
             app.apiKey = apiKey;
-            localStorage.setItem(STORAGE_KEYS.API_KEY, apiKey);
+            localStorage.setItem(DataManager.STORAGE_KEYS.API_KEY, apiKey);
             
             closeModal('apiKeyModal');
             showToast('APIキーを保存しました', 'success');
@@ -3176,9 +3191,7 @@ ${quarterlyImprovements.slice(-10).map(imp => {
 </script>
 <!-- JavaScript -->
 <script src="js/utils.js"></script>
-<script>
-    // ここから元のアプリケーションコードが続く
-    <script src="js/data.js"></script>
-    <script src="js/ui.js"></script>
+<script src="js/data.js"></script>
+<script src="js/ui.js"></script>
 </body>
 </html>

--- a/js/ui.js
+++ b/js/ui.js
@@ -46,3 +46,9 @@ const UI = {
         }
     }
 };
+
+// グローバル関数として公開
+window.showToast = UI.showToast.bind(UI);
+window.showModal = UI.showModal.bind(UI);
+window.closeModal = UI.closeModal.bind(UI);
+window.showSection = UI.showSection.bind(UI);


### PR DESCRIPTION
## Summary
- add `saveData`/`loadData` helper functions
- use `DataManager.STORAGE_KEYS` everywhere
- reload data in `handleStorageChange`
- make swipe navigation work on mobile

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68565bc443e48330bcca1c20ab76d314