### PR TITLE
Fix mobile swipe and calendar start date

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -292,6 +292,7 @@
             padding-bottom: 100px;
             max-width: 1200px;
             margin: 0 auto;
+            touch-action: pan-y;
         }
 
         /* セクション */

--- a/index.html
+++ b/index.html
@@ -515,6 +515,7 @@ if ('serviceWorker' in navigator) {
     loadData();
     
     renderDashboard();
+    goToToday();
     setupEventListeners();
     checkDailyReminder();
     requestNotificationPermission();


### PR DESCRIPTION
## Summary
- allow horizontal swipe gestures in main content
- show current month on initial calendar display

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68566b29416c8330817838fb7a5d661d